### PR TITLE
Surpport self host gitlab

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 react-issue-ganttchart
 ===================
 
-This is a single page application created with React to display Github/Gitlab issues as a Gantt chart.  
+This is a single page application created with React to display github.com / gitlab.com / your-self-host.gitlab.com issues as a Gantt chart.  
 Repository URL and personal access token are required, but not the rest.  
 No backend is required, and the token is stored in a cookie.  
 
@@ -11,9 +11,10 @@ No backend is required, and the token is stored in a cookie.
 https://lamact.github.io/react-issue-ganttchart/
 
 ## Requirements
-- URL (your repository's path)  
-  ex: https://github.com/lamact/react-issue-ganttchart
-- Personal Access Token  
+- Your Repository's Path (github.com / gitlab.com / your.self-host.gitlab.com)  
+  ex) https://github.com/lamact/react-issue-ganttchart
+
+- Personal Access Token:   
   GitHub: https://github.com/settings/tokens/new Scopes: public_repo, write:discussion  
   GitLab: https://gitlab.com/-/profile/personal_access_tokens 
 

--- a/src/functions/Common/IssueAPI.js
+++ b/src/functions/Common/IssueAPI.js
@@ -1,5 +1,5 @@
 import { isGitHubURL } from '../GitHub/GitHubURLHelper.js';
-import { isGitLabURL } from '../GitLab/GitLabURLHelper.js';
+import { isGitLabURL, getSelfHostingGitLabDomain } from '../GitLab/GitLabURLHelper.js';
 import {
   getGitHubIssuesFromAPI,
   updateGitHubIssueFromGanttTask,
@@ -16,11 +16,11 @@ import {
 } from '../GitLab/GitLabAPI.js';
 
 export const getIssuesFromAPI = async (gantt, git_url, token, selected_labels) => {
-  gantt.clearAll(); 
+  gantt.clearAll();
   if (isGitHubURL(git_url)) {
     getGitHubIssuesFromAPI(gantt, git_url, selected_labels);
   }
-  if (isGitLabURL(git_url)) {
+  if (isGitLabURL(git_url) || getSelfHostingGitLabDomain(git_url) !== null) {
     getGitLabIssuesFromAPI(gantt, git_url, token, selected_labels);
   }
 }
@@ -29,7 +29,7 @@ export const setLabelListOfRepoFromAPI = async (_this, git_url, token) => {
   if (isGitHubURL(git_url)) {
     setGitHubLabelListOfRepoFromAPI(_this, git_url);
   }
-  if (isGitLabURL(git_url)) {
+  if (isGitLabURL(git_url) || getSelfHostingGitLabDomain(git_url) !== null) {
     setGitLabLabelListOfRepoFromAPI(_this, git_url, token);
   }
 }
@@ -38,7 +38,7 @@ export const updateIssueByAPI = (gantt_task_id, token, gantt, git_url) => {
   if (isGitHubURL(git_url)) {
     updateGitHubIssueFromGanttTask(gantt_task_id, token, gantt, git_url);
   }
-  if (isGitLabURL(git_url)) {
+  if (isGitLabURL(git_url) || getSelfHostingGitLabDomain(git_url) !== null) {
     updateGitLabIssueFromGanttTask(gantt_task_id, token, gantt, git_url);
   }
 }
@@ -47,7 +47,7 @@ export const openIssueAtBrowser = (gantt_task_id, git_url) => {
   if (isGitHubURL(git_url)) {
     openGitHubIssueAtBrowser(gantt_task_id, git_url);
   }
-  if (isGitLabURL(git_url)) {
+  if (isGitLabURL(git_url) || getSelfHostingGitLabDomain(git_url) !== null) {
     openGitLabIssueAtBrowser(gantt_task_id, git_url);
   }
 };
@@ -56,7 +56,7 @@ export const openNewIssueAtBrowser = (gantt_task_id, git_url) => {
   if (isGitHubURL(git_url)) {
     openGitHubNewIssueAtBrowser(gantt_task_id, git_url);
   }
-  if (isGitLabURL(git_url)) {
+  if (isGitLabURL(git_url) || getSelfHostingGitLabDomain(git_url) !== null) {
     openGitLabNewIssueAtBrowser(gantt_task_id, git_url);
   }
 }

--- a/src/functions/GitLab/GitLabURLHelper.js
+++ b/src/functions/GitLab/GitLabURLHelper.js
@@ -1,10 +1,34 @@
 import { adjustURL } from '../Common/Parser.js';
 
-const GitLabAPIURL = "https://gitlab.com/api/v4/projects/";
-const GitLabURL = "https://gitlab.com/";
-
 export const isGitLabURL = (git_url) => {
   return /gitlab\.com/.test(git_url);
+}
+
+export const getSelfHostingGitLabDomain = (git_url) => {
+  const split_git_url = git_url.split('/');
+  if (split_git_url.length >= 3) {
+    return split_git_url[2];
+  }
+  return null;
+}
+
+const switchGitLabDomain = (git_url) => {
+  let gitlab_domain = null;
+  const self_hosting_gitlab_domain = getSelfHostingGitLabDomain(git_url);
+  if (self_hosting_gitlab_domain !== null) {
+    gitlab_domain = "https://" + self_hosting_gitlab_domain + "/";
+  } else {
+    gitlab_domain = "https://gitlab.com/";
+  }
+  return gitlab_domain;
+}
+
+const getGitLabURL = (git_url) => {
+  return switchGitLabDomain(git_url);
+}
+
+const getGitLabAPIURL = (git_url) => {
+  return switchGitLabDomain(git_url) + "api/v4/projects/";
 }
 
 const getGitLabNameSpaceFromGitURL = (git_url) => {
@@ -41,34 +65,34 @@ export const getGitLabAPIURLIssueFilterdLabel = (git_url, token, labels) => {
     });
   }
   const url = adjustURL(git_url);
-  return GitLabAPIURL + getGitLabNameSpaceFromGitURL(url) + "%2F" + getGitLabProjectFromGitURL(url) + '/issues' + post_fix_str;
+  return getGitLabAPIURL(git_url) + getGitLabNameSpaceFromGitURL(url) + "%2F" + getGitLabProjectFromGitURL(url) + '/issues' + post_fix_str;
 }
 
 export const getGitLabAPIURLIssue = (git_url, token, labels) => {
   const post_fix_str = postFixToken(token);
   const url = adjustURL(git_url);
-  return GitLabAPIURL + getGitLabNameSpaceFromGitURL(url) + "%2F" + getGitLabProjectFromGitURL(url) + '/issues' + post_fix_str;
+  return getGitLabAPIURL(git_url) + getGitLabNameSpaceFromGitURL(url) + "%2F" + getGitLabProjectFromGitURL(url) + '/issues' + post_fix_str;
 }
 
 export const getGitabAPIURLIssuebyNumber = (git_url, token, number) => {
   const post_fix_str = postFixToken(token);
   const url = adjustURL(git_url);
-  return GitLabAPIURL + getGitLabNameSpaceFromGitURL(url) + "%2F" + getGitLabProjectFromGitURL(url) + '/issues/' + number + post_fix_str;
+  return getGitLabAPIURL(git_url) + getGitLabNameSpaceFromGitURL(url) + "%2F" + getGitLabProjectFromGitURL(url) + '/issues/' + number + post_fix_str;
 }
 
 export const getGitLabAPIURLLabel = (git_url, token) => {
   const post_fix_str = postFixToken(token);
   const url = adjustURL(git_url);
-  return GitLabAPIURL + getGitLabNameSpaceFromGitURL(url) + "%2F" + getGitLabProjectFromGitURL(url) + '/labels' + post_fix_str;
+  return getGitLabAPIURL(git_url) + getGitLabNameSpaceFromGitURL(url) + "%2F" + getGitLabProjectFromGitURL(url) + '/labels' + post_fix_str;
 }
 
 export const getGitLabURLIssuebyNumber = (git_url, number) => {
   const url = adjustURL(git_url);
-  return GitLabURL + getGitLabNameSpaceFromGitURL(url) + "/" + getGitLabProjectFromGitURL(url)+ "/-/issues/" + number;
+  return getGitLabURL(git_url) + getGitLabNameSpaceFromGitURL(url) + "/" + getGitLabProjectFromGitURL(url) + "/-/issues/" + number;
 }
 
 export const getGitLabURLNewIssueWithTemplate = (git_url) => {
   const url = adjustURL(git_url);
-  return GitLabURL + getGitLabNameSpaceFromGitURL(url) + "/" + getGitLabProjectFromGitURL(url)
-         + "/issues/new?issue[description]=";
+  return getGitLabURL(git_url) + getGitLabNameSpaceFromGitURL(url) + "/" + getGitLabProjectFromGitURL(url)
+    + "/issues/new?issue[description]=";
 }

--- a/src/functions/GitLab/GitLabURLHelper.js
+++ b/src/functions/GitLab/GitLabURLHelper.js
@@ -17,7 +17,8 @@ const switchGitLabDomain = (git_url) => {
   const self_hosting_gitlab_domain = getSelfHostingGitLabDomain(git_url);
   if (self_hosting_gitlab_domain !== null) {
     gitlab_domain = "https://" + self_hosting_gitlab_domain + "/";
-  } else {
+  }
+  if(isGitLabURL(git_url)) {
     gitlab_domain = "https://gitlab.com/";
   }
   return gitlab_domain;


### PR DESCRIPTION
gilab.comではなくexample.gilab.comでセルフホスティングされたGitlabサーバにも対応可能なように改修した