### PR TITLE
reducer change brank url foregive

### DIFF
--- a/src/State/Reducer.js
+++ b/src/State/Reducer.js
@@ -126,6 +126,7 @@ export const handleGitURLChange = (
     gantt.message({ text: 'Access GitLab.com' });
   } else if (getSelfHostingGitLabDomain(git_url) !== null) {
     gantt.message({ text: 'Access Maybe GitLab.self-host' });
+  } else if (git_url === '') {
   } else {
     gantt.message({ text: 'Not a valid URL.', type: 'error' });
     return null;


### PR DESCRIPTION
空白のurlとなった場合
元の表示に戻すのではなく，空白を許す